### PR TITLE
OCaml 4.12.0 has Unix.SO_REUSEPORT

### DIFF
--- a/src/uwt_compat.ml
+++ b/src/uwt_compat.ml
@@ -97,6 +97,9 @@ module Lwt_unix = struct
     | SO_ACCEPTCONN
     | TCP_NODELAY
     | IPV6_ONLY
+#if OCAML_VERSION >= (4, 12, 0)
+    | SO_REUSEPORT
+#endif
   type socket_int_option = Unix.socket_int_option =
     | SO_SNDBUF
     | SO_RCVBUF

--- a/src/uwt_compat.mli
+++ b/src/uwt_compat.mli
@@ -105,6 +105,9 @@ module Lwt_unix : sig
       | SO_ACCEPTCONN
       | TCP_NODELAY
       | IPV6_ONLY
+#if OCAML_VERSION >= (4, 12, 0)
+      | SO_REUSEPORT
+#endif
     type socket_int_option = Unix.socket_int_option =
       | SO_SNDBUF
       | SO_RCVBUF


### PR DESCRIPTION
The definition was introduced in ocaml/ocaml#9869 and then moved to the end of the variant in ocaml/ocaml#10073

BTW thanks for writing this excellent library. I've been using it in https://github.com/moby/vpnkit : network stack for rootless docker on Linux and inside Docker Desktop on Mac and Windows. It's been rock-solid.