### PR TITLE
opam: requires Automake

### DIFF
--- a/uwt.opam
+++ b/uwt.opam
@@ -26,6 +26,7 @@ depends: [
   "base-bytes"
   "conf-autoconf" {build} # pin only
   "conf-pkg-config" {build}
+  "conf-automake" {build}
   "ocamlfind" {build}
   "cppo" {build & >= "1.3"}
   "omake" {build}


### PR DESCRIPTION
```shell
  #  cd . && /bin/bash /home/runner/work/cppo/cppo/_opam/.opam-switch/build/uwt.0.3.3/libuv/missing automake-1.15 --foreign
  # /home/runner/work/cppo/cppo/_opam/.opam-switch/build/uwt.0.3.3/libuv/missing: line 81: automake-1.15: command not found
  # WARNING: 'automake-1.15' is missing on your system.
  #          You should only need it if you modified 'Makefile.am' or
  #          'configure.ac' or m4 files included by 'configure.ac'.
  #          The 'automake' program is part of the GNU Automake package:
  #          <http://www.gnu.org/software/automake>
  #          It also requires GNU Autoconf, GNU m4 and Perl in order to run:
  #          <http://www.gnu.org/software/autoconf>
  #          <http://www.gnu.org/software/m4/>
  #          <http://www.perl.org/>
  # gmake: *** [Makefile:1106: Makefile.in] Error 1
  # *** ERROR: couldn't compile libuv
  # *** omake error:
  #    File /home/runner/work/cppo/cppo/_opam/lib/omake/configure/Configure.om: line 92, characters 4-11
  #    early exit(1) requested by an omake file
  
  
  
  <><> Error report <><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
  ┌─ The following actions failed
  │ λ build uwt 0.3.3
  └─ 
```